### PR TITLE
Update semi-annual-channel-targeted-2020.md

### DIFF
--- a/OfficeUpdates/semi-annual-channel-targeted-2020.md
+++ b/OfficeUpdates/semi-annual-channel-targeted-2020.md
@@ -131,8 +131,6 @@ ms.locfileid: "43714689"
 
 - <span data-ttu-id="6721c-169">**Obtenir les statistiques sur votre classeur :** les statistiques de classeur fournissent une vue d’ensemble du contenu d’un classeur, afin de vous aider à découvrir plus facilement son contenu.</span><span class="sxs-lookup"><span data-stu-id="6721c-169">**Get stats on your workbook:** Workbook Statistics provides an overview of the content of a workbook, to help you more easily discover its contents.</span></span>
 
-- <span data-ttu-id="6721c-170">**Enregistrer les formes en tant qu’images :** en quelques clics seulement, enregistrez une forme, une icône ou un autre objet sous la forme d’un fichier image pour le réutiliser ailleurs.</span><span class="sxs-lookup"><span data-stu-id="6721c-170">**Save shapes as pictures:** In just a few clicks, save a shape, icon, or other object as a picture file so you can reuse it elsewhere.</span></span> [<span data-ttu-id="6721c-171">En savoir plus</span><span class="sxs-lookup"><span data-stu-id="6721c-171">Learn more</span></span>](https://support.office.com/article/3c4f9ca4-945a-4c33-af91-d10e4e3ea715)
-
 
 
 ### <a name="outlook"></a><span data-ttu-id="6721c-172">Outlook</span><span class="sxs-lookup"><span data-stu-id="6721c-172">Outlook</span></span>


### PR DESCRIPTION
this feature doesn't exist on excel (i check on my own), and it's confirmed in the french support help : https://support.office.com/fr-fr/article/enregistrer-une-image-au-format-jpg-gif-ou-png-3c4f9ca4-945a-4c33-af91-d10e4e3ea715?ui=fr-FR&rs=fr-FR&ad=FR

but in the english one, they didn't remove excel as the french one : https://support.office.com/en-us/article/save-a-picture-or-other-graphic-as-a-separate-file-3c4f9ca4-945a-4c33-af91-d10e4e3ea715?ui=en-US&rs=en-001&ad=US

however the feature is not listed in the product fields available in italics (word, outlook, powerpoint but no excel)
but they mention excel further down the page : 
"In PowerPoint, Word, and Excel, the following procedure works for photos, shapes, charts, SmartArt graphics, digital ink, and text boxes."